### PR TITLE
Avoid continuing if config was not loaded

### DIFF
--- a/bing_wallpaper.sh
+++ b/bing_wallpaper.sh
@@ -278,6 +278,10 @@ main() {
 
     # Normal operation
     load_config
+    if [ $? -ne 0 ]; then
+        echo "✗ Failed loading config"
+        exit 1
+    fi
 
     # Run download with output
     echo "Starting Bing wallpaper update..."


### PR DESCRIPTION
If config is not loaded, others errors will occur which might confuse the user.